### PR TITLE
Change parts to be sc.defaultParallelism

### DIFF
--- a/src/main/scala/com/github/ehiggs/spark/terasort/TeraGen.scala
+++ b/src/main/scala/com/github/ehiggs/spark/terasort/TeraGen.scala
@@ -48,7 +48,7 @@ object TeraGen {
       .setAppName(s"TeraGen ($size)")
     val sc = new SparkContext(conf)
 
-    val parts = sc.defaultMinPartitions
+    val parts = sc.defaultParallelism
     val recordsPerPartition = outputSizeInBytes / 100 / parts.toLong
     val numRecords = recordsPerPartition * parts.toLong
 


### PR DESCRIPTION
currently parts is set as sc.defaultMinPartitions which is less than or equal to 2. This is not efficient for generating 1T data with only 2 tasks.  I think it should be defaultParallelism (or allow user pass parameter to specify that, although we can set defaultParallelism through spark conf "spark.default.parallelism")
