### PR TITLE
add explicitely exiting  for TeraSort.scala

### DIFF
--- a/src/main/scala/com/github/ehiggs/spark/terasort/TeraSort.scala
+++ b/src/main/scala/com/github/ehiggs/spark/terasort/TeraSort.scala
@@ -63,6 +63,5 @@ object TeraSort {
     sorted.saveAsNewAPIHadoopFile[TeraOutputFormat](outputFile)
     
     System.exit(0) //explicitly exiting
-	
   }
 }

--- a/src/main/scala/com/github/ehiggs/spark/terasort/TeraSort.scala
+++ b/src/main/scala/com/github/ehiggs/spark/terasort/TeraSort.scala
@@ -61,5 +61,8 @@ object TeraSort {
     val sorted = dataset.repartitionAndSortWithinPartitions(
       new TeraSortPartitioner(dataset.partitions.length))
     sorted.saveAsNewAPIHadoopFile[TeraOutputFormat](outputFile)
+    
+    System.exit(0) //explicitly exiting
+	
   }
 }


### PR DESCRIPTION
the TeraSort.scala can invoke other threads or plugin, such as RDMA messaging.  if the TeraSort.scala code do not exit explicetely, those threads or plugin will hangs there, which also cause the job program hangs infinitely.  