### PR TITLE
Updated to latest Spark version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ but it is not the same TeraSort program that currently holds the
 
 `mvn install`
 
-The default is to link against Spark 2.1 jars (released December 2016). If you plan to run using an older version of Spark (e.g. 1.6) you will have to try `-Dspark.version=1.6`. If possible, it's probably a better idea to just update to a more recent version or Spark.
+The default is to link against Spark 2.4.4 jars (released September 2019). If you plan to run using an older version of Spark (e.g. 1.6) you will have to try `-Dspark.version=1.6`. If possible, it's probably a better idea to just update to a more recent version or Spark.
 
 # Running
 
@@ -22,17 +22,17 @@ The default is to link against Spark 2.1 jars (released December 2016). If you p
 ## Generate data
 
     ./bin/spark-submit --class com.github.ehiggs.spark.terasort.TeraGen 
-    path/to/spark-terasort/target/spark-terasort-1.0-SNAPSHOT-jar-with-dependencies.jar 
+    path/to/spark-terasort/target/spark-terasort-1.2-SNAPSHOT-jar-with-dependencies.jar 
     1g file://$HOME/data/terasort_in 
 
 ## Sort the data
     ./bin/spark-submit --class com.github.ehiggs.spark.terasort.TeraSort
-    path/to/spark-terasort/target/spark-terasort-1.0-SNAPSHOT-jar-with-dependencies.jar 
+    path/to/spark-terasort/target/spark-terasort-1.2-SNAPSHOT-jar-with-dependencies.jar 
     file://$HOME/data/terasort_in file://$HOME/data/terasort_out
 
 ## Validate the data
     ./bin/spark-submit --class com.github.ehiggs.spark.terasort.TeraValidate
-    path/to/spark-terasort/target/spark-terasort-1.0-SNAPSHOT-jar-with-dependencies.jar 
+    path/to/spark-terasort/target/spark-terasort-1.2-SNAPSHOT-jar-with-dependencies.jar 
     file://$HOME/data/terasort_out file://$HOME/data/terasort_validate
 
 # Known issues

--- a/pom.xml
+++ b/pom.xml
@@ -202,8 +202,8 @@
 
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <scala.version>2.12.10</scala.version>
-  <scala.binary.version>2.12</scala.binary.version>
+  <scala.version>2.11.12</scala.version>
+  <scala.binary.version>2.11</scala.binary.version>
   <spark.version>2.4.4</spark.version>
 </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <plugin>
       <groupId>net.alchim31.maven</groupId>
       <artifactId>scala-maven-plugin</artifactId>
+      <version>4.3.0</version>
       <executions>
         <execution>
           <goals>
@@ -94,6 +95,7 @@
           <jvmArg>-Xms64m</jvmArg>
           <jvmArg>-Xmx1024m</jvmArg>
         </jvmArgs>
+        <scalaVersion>${scala.version}</scalaVersion>
       </configuration>
   </plugin>
   <plugin>                                                                  

--- a/pom.xml
+++ b/pom.xml
@@ -200,9 +200,9 @@
 
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <scala.version>2.12.8</scala.version>
+  <scala.version>2.12.10</scala.version>
   <scala.binary.version>2.12</scala.binary.version>
-  <spark.version>2.4.2</spark.version>
+  <spark.version>2.4.4</spark.version>
 </properties>
 
 <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>com.github.ehiggs</groupId>
 <artifactId>spark-terasort</artifactId>
-<version>1.1-SNAPSHOT</version>
+<version>1.2-SNAPSHOT</version>
 
 <name>spark-terasort</name>
 <url>https://github.com/ehiggs/spark-terasort</url>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,9 @@
           <jvmArg>-Xms64m</jvmArg>
           <jvmArg>-Xmx1024m</jvmArg>
         </jvmArgs>
+		<args>
+			<arg>-nobootcp</arg>
+		</args>
         <scalaVersion>${scala.version}</scalaVersion>
       </configuration>
   </plugin>


### PR DESCRIPTION
Updated the Spark and Scala versions so that TeraSort can run with the latest Spark version. Also updated the `scala-maven-plugin`.  Adjusted the README notes as appropriate for the version changes.