### PR TITLE
Fix TeraSortPartitioner.getPartition

### DIFF
--- a/src/main/scala/com/github/ehiggs/spark/terasort/TeraSortPartitioner.scala
+++ b/src/main/scala/com/github/ehiggs/spark/terasort/TeraSortPartitioner.scala
@@ -29,7 +29,7 @@ case class TeraSortPartitioner(numPartitions: Int) extends Partitioner {
 
   import TeraSortPartitioner._
 
-  val rangePerPart : Long = (max - min) / numPartitions
+  val rangePerPart : Long = ((max - min) / numPartitions).ceil.toLong
 
   override def getPartition(key: Any): Int = {
     val b = key.asInstanceOf[Array[Byte]]

--- a/src/main/scala/com/github/ehiggs/spark/terasort/TeraSortPartitioner.scala
+++ b/src/main/scala/com/github/ehiggs/spark/terasort/TeraSortPartitioner.scala
@@ -18,6 +18,7 @@
 package com.github.ehiggs.spark.terasort
 
 import com.google.common.primitives.Longs
+import scala.math.BigDecimal
 
 import org.apache.spark.Partitioner
 
@@ -29,7 +30,8 @@ case class TeraSortPartitioner(numPartitions: Int) extends Partitioner {
 
   import TeraSortPartitioner._
 
-  val rangePerPart : Long = ((max - min) / numPartitions).ceil.toLong
+  val rangePerPart : Long =
+    (BigDecimal(max - min) / numPartitions).setScale(0, BigDecimal.RoundingMode.UP).toLong
 
   override def getPartition(key: Any): Int = {
     val b = key.asInstanceOf[Array[Byte]]


### PR DESCRIPTION
When running 100TB sort with 100,000 partitions, I encountered an edge case where `TeraSortPartitioner.getPartition` returned 100,000, where the valid range is [0, 100,000), causing Spark to throw an `ArrayIndexOutOfBoundsException` at https://github.com/apache/spark/blob/2f8613f22c0750c00cf1dcfb2f31c431d8dc1be7/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java#L219.

This PR fixes `getPartition` such that it will never return a value that is `>= numPartitions`.